### PR TITLE
Fix palettes and loading order

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -16,7 +16,7 @@ use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
-
+use Contao\NewsBundle\ContaoNewsBundle;
 
 /**
  * Plugin for the Contao Manager.
@@ -32,7 +32,7 @@ class Plugin implements BundlePluginInterface
     {
         return [
             BundleConfig::create(ContaoChangeNewsMoreBundle::class)
-                ->setLoadAfter([ContaoCoreBundle::class])
+                ->setLoadAfter([ContaoCoreBundle::class, ContaoNewsBundle::class])
         ];
     }
 }

--- a/src/Resources/contao/dca/tl_news.php
+++ b/src/Resources/contao/dca/tl_news.php
@@ -1,10 +1,6 @@
-<?php 
+<?php
 
-$GLOBALS['TL_DCA']['tl_news']['palettes']['default'] = str_replace(
-    ',source',
-    ',source,linktext',
-    $GLOBALS['TL_DCA']['tl_news']['palettes']['default']
-); 
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
 
 $GLOBALS['TL_DCA']['tl_news']['fields']['linktext'] = array ( 
     'label'                   => &$GLOBALS['TL_LANG']['tl_news']['linktext'],
@@ -13,3 +9,13 @@ $GLOBALS['TL_DCA']['tl_news']['fields']['linktext'] = array (
     'eval'                    => array('maxlength'=>255, 'tl_class'=>'w50'),
     'sql'                     => "varchar(255) NOT NULL default ''"
 );
+
+$pm = PaletteManipulator::create()
+    ->addField('linktext', 'source_legend', PaletteManipulator::POSITION_APPEND)
+;
+
+foreach ($GLOBALS['TL_DCA']['tl_news']['palettes'] as $name => $palette) {
+    if (\is_string($palette)) {
+        $pm->applyToPalette($name, 'tl_news');
+    }
+}


### PR DESCRIPTION
This PR fixes two things:

1. In newer Contao versions, there exist several palettes for `tl_news`, not just `default`. Thus the `linktext` field would be missing in those new palettes.
2. The extension did not properly define the loading order so far, so in some circumstances the extension would have had no effect on the palette anyway.